### PR TITLE
refactor: replace install bun script from oven-sh/bun/tree/main/dockerhub

### DIFF
--- a/src/bun/README.md
+++ b/src/bun/README.md
@@ -7,7 +7,7 @@ Install the Bun toolkit
 
 ```json
 "features": {
-    "ghcr.io/alertbox/devcontainer-features/bun:1": {}
+    "ghcr.io/alertbox/devcontainer-features/bun:2": {}
 }
 ```
 

--- a/src/bun/devcontainer-feature.json
+++ b/src/bun/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "id": "bun",
   "name": "Bun",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Installs Bun, an all-in-one toolkit for JavaScript and TypeScript apps",
   "options": {
     "version": {


### PR DESCRIPTION
this changeset is to replace the bun install script from oven-sh/bun/tree/main/dockerhub version instead of using https://bun.sh/install to install.