### PR TITLE
feat: add packages option to allow install global tools

### DIFF
--- a/src/bun/README.md
+++ b/src/bun/README.md
@@ -16,6 +16,7 @@ Install the Bun toolkit
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | version | Version of the Bun CLI to install (or "latest") | string | latest |
+| packages | Optional comma separated list of packages to install globally. | string | - |
 
 ---
 

--- a/src/bun/devcontainer-feature.json
+++ b/src/bun/devcontainer-feature.json
@@ -11,7 +11,12 @@
       ],
       "default": "latest",
       "description": "Select or enter a version."
-    }
+    },
+    "packages": {
+      "type": "string",
+      "default": "",
+      "description": "Optional comma separated list of packages to install globally."
+    },
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
this changeset is to refactor how the bun is installed and the parameters to install global tools.

- add packages option to install global tools via `bun add -g`
- improve bun install based on the bun.sh install script and docker image
- improve documentation